### PR TITLE
Add single-frame helper for video matting

### DIFF
--- a/RmbgSharp.Example/Program.cs
+++ b/RmbgSharp.Example/Program.cs
@@ -9,7 +9,7 @@ public class Program
         Console.WriteLine("Removing the background from \"input.png\", please wait a while.");
 
         RobustVideoMattingRemover backgroundRemover = new RobustVideoMattingRemover("rvm_mobilenetv3_fp32.onnx", false, true);
-        backgroundRemover.RemoveBackground((Bitmap)Image.FromFile("input.png")).Save("output.png");
+        backgroundRemover.RemoveBackgroundSingleFrame((Bitmap)Image.FromFile("input.png")).Save("output.png");
 
         Console.WriteLine("Succesfully removed the background from \"input.png\"!");
         Console.WriteLine("The result image is exported as \"output.png\".");

--- a/RmbgSharp/RobustVideoMattingRemover.cs
+++ b/RmbgSharp/RobustVideoMattingRemover.cs
@@ -56,6 +56,20 @@ namespace RmbgSharp
         }
 
         /// <summary>
+        /// Remove the background from a single frame. This helper resets the
+        /// internal recurrent states before processing so no temporal
+        /// information is carried over from previous frames.
+        /// </summary>
+        /// <param name="bitmap">Frame to process.</param>
+        /// <param name="downsampleRatio">Downsample ratio used by the model.</param>
+        /// <returns>Bitmap with alpha channel representing foreground.</returns>
+        public Bitmap RemoveBackgroundSingleFrame(Bitmap bitmap, float downsampleRatio = 0.25f)
+        {
+            ResetState();
+            return RemoveBackground(bitmap, downsampleRatio);
+        }
+
+        /// <summary>
         /// Remove the background from a frame using the RVM model.
         /// </summary>
         /// <param name="bitmap">Frame to process.</param>


### PR DESCRIPTION
## Summary
- add `RemoveBackgroundSingleFrame` to reset RVM state when processing individual frames
- update example to use new single-frame helper

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689602fe7830832a9b19568e1ab2feb7